### PR TITLE
Handle open-in-new-tab natively

### DIFF
--- a/client/app/bundles/PullRequestDashboard/containers/pull-request-dashboard/item.js
+++ b/client/app/bundles/PullRequestDashboard/containers/pull-request-dashboard/item.js
@@ -29,11 +29,6 @@ const getRepoAbbr = (repo) => {
   return abbr.toUpperCase();
 };
 
-const handleClick = (url) => () => {
-  const win = window.open(url, '_blank');
-  win.focus();
-};
-
 const Item = ({
   pullRequest: {
     author,
@@ -46,7 +41,7 @@ const Item = ({
     url,
   },
 }) => (
-  <span { ...styles.container } onClick={ handleClick(url) }>
+  <a { ...styles.container } href={ url } target="_blank">
     <div { ...styles.prContainer }>
       <p { ...styles.repo }>{ repo && getRepoAbbr(repo) }</p>
 
@@ -73,7 +68,7 @@ const Item = ({
         role="Reviewer"
       />
     </div>
-  </span>
+  </a>
 );
 
 Item.propTypes = {


### PR DESCRIPTION
Browsers have native support for "Open in New Tab" functionality just by setting `target="_blank"`. :-) Using `window.open().focus()` makes it show `about:blank` in the location bar in the new tab while it's loading which makes it seem like it's not doing anything.

Usually it's fine, but with slow internet, it just looks like it the opener script broke. :-)